### PR TITLE
Req for comment: Makefile updates

### DIFF
--- a/nacl/Makefile
+++ b/nacl/Makefile
@@ -9,7 +9,8 @@ PNACL_CXX = $(PNACL_TC_PATH)/bin/pnacl-clang++
 PNACL_FINALIZE = $(PNACL_TC_PATH)/bin/pnacl-finalize
 
 CXXFLAGS = -fno-exceptions -fno-rtti -O3 -I$(NACL_SDK_ROOT)/include \
-	-DIS_64BIT -DNDEBUG -DNO_PREFETCH -std=gnu++11 \
+	-DIS_64BIT -DNDEBUG -DNO_PREFETCH -std=gnu++11 -DUSE_POPCNT \
+	-mllvm -inline-threshold=1000 \
 	-DANTI -DATOMIC -DHORDE -DKOTH -DRACE -DTHREECHECK
 
 LDFLAGS = -L$(NACL_SDK_ROOT)/lib/pnacl/Release -O3 -lppapi_cpp -lppapi -lpthread


### PR DESCRIPTION
- add USE_POPCNT
- adjust inlining
- add compression (documented as not impacting perf)

Open questions:
- best inlining value? Default is 225, which results in a 340kb nexe. Setting to 1000 builds a 520kb nexe.
- POPCNT change didn't seem to affect performance on my core i7-3615QM. PEXT might be possible as well, but would only affect new computers.
- pnacl also has [simd vector support](https://developer.chrome.com/native-client/reference/pnacl-c-cpp-language-support#portable-simd-vectors) but might require porting
